### PR TITLE
Made type of `contentType` property optional

### DIFF
--- a/Sources/TextView/TextView.swift
+++ b/Sources/TextView/TextView.swift
@@ -40,7 +40,7 @@ public struct TextView: UIViewRepresentable {
 	private let font: UIFont
 	private let textColor: UIColor
 	private let backgroundColor: UIColor
-	private let contentType: ContentType
+	private let contentType: ContentType?
 	private let autocorrection: Autocorrection
 	private let autocapitalization: Autocapitalization
 	private let isSecure: Bool
@@ -56,7 +56,7 @@ public struct TextView: UIViewRepresentable {
 		font: UIFont = Self.defaultFont,
 		textColor: UIColor = .black,
 		backgroundColor: UIColor = .white,
-		contentType: ContentType = .name,
+		contentType: ContentType? = nil,
 		autocorrection: Autocorrection = .default,
 		autocapitalization: Autocapitalization = .sentences,
 		isSecure: Bool = false,
@@ -88,7 +88,7 @@ public struct TextView: UIViewRepresentable {
 		font: UIFont = Self.defaultFont,
 		textColor: UIColor = .black,
 		backgroundColor: UIColor = .white,
-		contentType: ContentType = .name,
+		contentType: ContentType? = nil,
 		autocorrection: Autocorrection = .default,
 		autocapitalization: Autocapitalization = .sentences,
 		isSecure: Bool = false,


### PR DESCRIPTION
Made type of `contentType` property optional and
Changed default value of `contentType` property to nil, matching the default value of `UITextView.textContentType`