### PR TITLE
feat: option to wait until commit for multi-stage input methods.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@
 - `isSelectable: Bool = true`
 - `isScrollingEnabled: Bool = true`
 - `isUserInteractionEnabled: Bool = true`
+- `shouldWaitUntilCommit: Bool = true`
+	- For multi-stage input methods, setting this to `false` would make TextView completely unusable.
+	- This option will ignore text changes when the user is still composing characters.
 
 ## Example
 

--- a/Sources/TextView/TextView.swift
+++ b/Sources/TextView/TextView.swift
@@ -46,6 +46,7 @@ public struct TextView: View {
 		private let isSelectable: Bool
 		private let isScrollingEnabled: Bool
 		private let isUserInteractionEnabled: Bool
+        private let shouldWaitUntilCommit: Bool
 		
 		public init(
 			text: Binding<String>,
@@ -61,7 +62,8 @@ public struct TextView: View {
 			isEditable: Bool,
 			isSelectable: Bool,
 			isScrollingEnabled: Bool,
-			isUserInteractionEnabled: Bool
+			isUserInteractionEnabled: Bool,
+            shouldWaitUntilCommit: Bool
 		) {
 			_text = text
 			_isEditing = isEditing
@@ -78,6 +80,7 @@ public struct TextView: View {
 			self.isSelectable = isSelectable
 			self.isScrollingEnabled = isScrollingEnabled
 			self.isUserInteractionEnabled = isUserInteractionEnabled
+            self.shouldWaitUntilCommit = shouldWaitUntilCommit
 		}
 		
 		public func makeCoordinator() -> Coordinator {
@@ -91,7 +94,11 @@ public struct TextView: View {
 		}
 		
 		public func updateUIView(_ textView: UITextView, context _: Context) {
-			textView.text = text
+            if shouldWaitUntilCommit
+                ? textView.markedTextRange == nil
+                : true {
+                textView.text = text
+            }
 			textView.textAlignment = textAlignment
 			textView.font = font
 			textView.textColor = textColor
@@ -140,6 +147,7 @@ public struct TextView: View {
 	private let isSelectable: Bool
 	private let isScrollingEnabled: Bool
 	private let isUserInteractionEnabled: Bool
+    private let shouldWaitUntilCommit: Bool
 	
 	public init(
 		text: Binding<String>,
@@ -160,7 +168,8 @@ public struct TextView: View {
 		isEditable: Bool = true,
 		isSelectable: Bool = true,
 		isScrollingEnabled: Bool = true,
-		isUserInteractionEnabled: Bool = true
+		isUserInteractionEnabled: Bool = true,
+        shouldWaitUntilCommit: Bool = true
 	) {
 		_text = text
 		_isEditing = isEditing
@@ -182,6 +191,7 @@ public struct TextView: View {
 		self.isSelectable = isSelectable
 		self.isScrollingEnabled = isScrollingEnabled
 		self.isUserInteractionEnabled = isUserInteractionEnabled
+        self.shouldWaitUntilCommit = shouldWaitUntilCommit
 	}
 	
 	private var _placeholder: String? {
@@ -203,7 +213,8 @@ public struct TextView: View {
 			isEditable: isEditable,
 			isSelectable: isSelectable,
 			isScrollingEnabled: isScrollingEnabled,
-			isUserInteractionEnabled: isUserInteractionEnabled
+			isUserInteractionEnabled: isUserInteractionEnabled,
+            shouldWaitUntilCommit: shouldWaitUntilCommit
 		)
 	}
 	

--- a/Sources/TextView/TextView.swift
+++ b/Sources/TextView/TextView.swift
@@ -94,9 +94,7 @@ public struct TextView: View {
 		}
 		
 		public func updateUIView(_ textView: UITextView, context _: Context) {
-			if shouldWaitUntilCommit
-				? textView.markedTextRange == nil
-				: true {
+			if !shouldWaitUntilCommit || textView.markedTextRange == nil {
 				textView.text = text
 			}
 			textView.textAlignment = textAlignment

--- a/Sources/TextView/TextView.swift
+++ b/Sources/TextView/TextView.swift
@@ -46,7 +46,7 @@ public struct TextView: View {
 		private let isSelectable: Bool
 		private let isScrollingEnabled: Bool
 		private let isUserInteractionEnabled: Bool
-        private let shouldWaitUntilCommit: Bool
+		private let shouldWaitUntilCommit: Bool
 		
 		public init(
 			text: Binding<String>,
@@ -63,7 +63,7 @@ public struct TextView: View {
 			isSelectable: Bool,
 			isScrollingEnabled: Bool,
 			isUserInteractionEnabled: Bool,
-            shouldWaitUntilCommit: Bool
+			shouldWaitUntilCommit: Bool
 		) {
 			_text = text
 			_isEditing = isEditing
@@ -80,7 +80,7 @@ public struct TextView: View {
 			self.isSelectable = isSelectable
 			self.isScrollingEnabled = isScrollingEnabled
 			self.isUserInteractionEnabled = isUserInteractionEnabled
-            self.shouldWaitUntilCommit = shouldWaitUntilCommit
+			self.shouldWaitUntilCommit = shouldWaitUntilCommit
 		}
 		
 		public func makeCoordinator() -> Coordinator {
@@ -94,11 +94,11 @@ public struct TextView: View {
 		}
 		
 		public func updateUIView(_ textView: UITextView, context _: Context) {
-            if shouldWaitUntilCommit
-                ? textView.markedTextRange == nil
-                : true {
-                textView.text = text
-            }
+			if shouldWaitUntilCommit
+				? textView.markedTextRange == nil
+				: true {
+				textView.text = text
+			}
 			textView.textAlignment = textAlignment
 			textView.font = font
 			textView.textColor = textColor
@@ -147,7 +147,7 @@ public struct TextView: View {
 	private let isSelectable: Bool
 	private let isScrollingEnabled: Bool
 	private let isUserInteractionEnabled: Bool
-    private let shouldWaitUntilCommit: Bool
+	private let shouldWaitUntilCommit: Bool
 	
 	public init(
 		text: Binding<String>,
@@ -169,7 +169,7 @@ public struct TextView: View {
 		isSelectable: Bool = true,
 		isScrollingEnabled: Bool = true,
 		isUserInteractionEnabled: Bool = true,
-        shouldWaitUntilCommit: Bool = true
+		shouldWaitUntilCommit: Bool = true
 	) {
 		_text = text
 		_isEditing = isEditing
@@ -191,7 +191,7 @@ public struct TextView: View {
 		self.isSelectable = isSelectable
 		self.isScrollingEnabled = isScrollingEnabled
 		self.isUserInteractionEnabled = isUserInteractionEnabled
-        self.shouldWaitUntilCommit = shouldWaitUntilCommit
+		self.shouldWaitUntilCommit = shouldWaitUntilCommit
 	}
 	
 	private var _placeholder: String? {
@@ -214,7 +214,7 @@ public struct TextView: View {
 			isSelectable: isSelectable,
 			isScrollingEnabled: isScrollingEnabled,
 			isUserInteractionEnabled: isUserInteractionEnabled,
-            shouldWaitUntilCommit: shouldWaitUntilCommit
+			shouldWaitUntilCommit: shouldWaitUntilCommit
 		)
 	}
 	


### PR DESCRIPTION
This PR implements a new option (`shouldWaitUntilCommit`) to ignore text changes while the user is still composing characters/phrases by multi-stage input methods, like Bopomofo for Traditional Chinese and Pinyin for Simplified Chinese. Since in my tests, this option didn't change the behavior for non-multi-stage keyboards like English, and not enabling this option means completely unusable for multi-stage input methods (more on this below), I set this option to `true` by default.

<details>
<summary>Details</summary>
Due to the nature of many languages, it's impossible to have every character on a keyboard, so they must compose characters with a sequence of basic key inputs. In iOS, a multi-stage input method would send the user's input sequence to TextView and mark the unfinished sequence (in visual looks like a selection), then trigger textViewDidChange. Before this PR, this view would get the current text in TextView and set to the binding, and the binding would then replace the text in the TextView, losing the mark of the unfinished sequence, thus interrupting the user's character composing. Enabling this option would check if there's any `markedTextRange` when `textViewDidChange` is fired, and avoid update text if so. This should change nothing when users don't use multi-stage input methods.
</details>