### PR TITLE
Keep cursor position after text updates when possible.

### DIFF
--- a/Sources/TextView/TextView.swift
+++ b/Sources/TextView/TextView.swift
@@ -95,7 +95,9 @@ public struct TextView: View {
 		
 		public func updateUIView(_ textView: UITextView, context _: Context) {
 			if !shouldWaitUntilCommit || textView.markedTextRange == nil {
+                let selectedRange = textView.selectedRange
 				textView.text = text
+                textView.selectedRange = selectedRange
 			}
 			textView.textAlignment = textAlignment
 			textView.font = font

--- a/Sources/TextView/TextView.swift
+++ b/Sources/TextView/TextView.swift
@@ -95,9 +95,9 @@ public struct TextView: View {
 		
 		public func updateUIView(_ textView: UITextView, context _: Context) {
 			if !shouldWaitUntilCommit || textView.markedTextRange == nil {
-                let selectedRange = textView.selectedRange
+				let selectedRange = textView.selectedRange
 				textView.text = text
-                textView.selectedRange = selectedRange
+				textView.selectedRange = selectedRange
 			}
 			textView.textAlignment = textAlignment
 			textView.font = font


### PR DESCRIPTION
Before this, when inserting text in between existing characters, the cursor would jump back to the end, making it hard to type in text in the middle.