### PR TITLE
Make sure that the text view puts the cursor at the end when it first becomes first responder

### DIFF
--- a/Sources/TextView/TextView.swift
+++ b/Sources/TextView/TextView.swift
@@ -95,13 +95,13 @@ public struct TextView: View {
 		
 		public func updateUIView(_ textView: UITextView, context _: Context) {
 			if !shouldWaitUntilCommit || textView.markedTextRange == nil {
-                let textViewWasEmpty = textView.text.isEmpty
-                var selectedRange = textView.selectedTextRange
+				let textViewWasEmpty = textView.text.isEmpty
+				var selectedRange = textView.selectedTextRange
 				textView.text = text
-                if textViewWasEmpty {
-                    selectedRange = textView.textRange(from: textView.endOfDocument, to: textView.endOfDocument)
-                }
-                textView.selectedTextRange = selectedRange
+				if textViewWasEmpty {
+					selectedRange = textView.textRange(from: textView.endOfDocument, to: textView.endOfDocument)
+				}
+				textView.selectedTextRange = selectedRange
 			}
 			textView.textAlignment = textAlignment
 			textView.font = font

--- a/Sources/TextView/TextView.swift
+++ b/Sources/TextView/TextView.swift
@@ -98,9 +98,9 @@ public struct TextView: View {
 				let textViewWasEmpty = textView.text.isEmpty
 				let selectedRange = textView.selectedTextRange
 				textView.text = text
-                textView.selectedTextRange = textViewWasEmpty
-                    ? textView.textRange(from: textView.endOfDocument, to: textView.endOfDocument)
-                    : selectedRange
+				textView.selectedTextRange = textViewWasEmpty
+					? textView.textRange(from: textView.endOfDocument, to: textView.endOfDocument)
+					: selectedRange
 			}
 			textView.textAlignment = textAlignment
 			textView.font = font

--- a/Sources/TextView/TextView.swift
+++ b/Sources/TextView/TextView.swift
@@ -95,9 +95,13 @@ public struct TextView: View {
 		
 		public func updateUIView(_ textView: UITextView, context _: Context) {
 			if !shouldWaitUntilCommit || textView.markedTextRange == nil {
-				let selectedRange = textView.selectedRange
+                let textViewWasEmpty = textView.text.isEmpty
+                var selectedRange = textView.selectedTextRange
 				textView.text = text
-				textView.selectedRange = selectedRange
+                if textViewWasEmpty {
+                    selectedRange = textView.textRange(from: textView.endOfDocument, to: textView.endOfDocument)
+                }
+                textView.selectedTextRange = selectedRange
 			}
 			textView.textAlignment = textAlignment
 			textView.font = font

--- a/Sources/TextView/TextView.swift
+++ b/Sources/TextView/TextView.swift
@@ -96,12 +96,11 @@ public struct TextView: View {
 		public func updateUIView(_ textView: UITextView, context _: Context) {
 			if !shouldWaitUntilCommit || textView.markedTextRange == nil {
 				let textViewWasEmpty = textView.text.isEmpty
-				var selectedRange = textView.selectedTextRange
+				let selectedRange = textView.selectedTextRange
 				textView.text = text
-				if textViewWasEmpty {
-					selectedRange = textView.textRange(from: textView.endOfDocument, to: textView.endOfDocument)
-				}
-				textView.selectedTextRange = selectedRange
+                textView.selectedTextRange = textViewWasEmpty
+                    ? textView.textRange(from: textView.endOfDocument, to: textView.endOfDocument)
+                    : selectedRange
 			}
 			textView.textAlignment = textAlignment
 			textView.font = font


### PR DESCRIPTION
When the text view is initialized, it is empty, and so its selected range is (0,0). After it’s populated with text, it would normally put the cursor at the end of the text, except for https://github.com/kenmueller/TextView/pull/21 which reset the position to the beginning.

You can reproduce the issue with an app like

```swift
struct ContentView: View {
    @State var input = "Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur."
    
    // Automatically become first responder for fast testing.
    @State var isEditing = true
    
    var body: some View {
        TextView(text: $input, isEditing: $isEditing)
    }
}
```