### PR TITLE
Let the client override `textView(_:shouldChangeTextIn:replacementText:)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@
 - `shouldWaitUntilCommit: Bool = true`
 	- For multi-stage input methods, setting this to `false` would make the `TextView` completely unusable.
 	- This option will ignore text changes when the user is still composing characters.
+-`shouldChange: TextView.ShouldChangeHandler = nil`
+	- `TextView.ShouldChangeHandler` is of type `(NSRange, String)` and is called
+	  with the arguments to `textView(_:shouldChangeTextIn:replacementText:)`.
+	  See that `UITextViewDelegate` method for more information.
 
 ## Example
 

--- a/Sources/TextView/TextView.swift
+++ b/Sources/TextView/TextView.swift
@@ -19,10 +19,7 @@ public struct TextView: View {
 			}
 			
 			public func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
-				guard let shouldChange = parent.shouldChange else {
-					return true
-				}
-				return shouldChange(range, text)
+				parent.shouldChange?(range, text) ?? true
 			}
 			
 			public func textViewDidChange(_ textView: UITextView) {

--- a/Sources/TextView/TextView.swift
+++ b/Sources/TextView/TextView.swift
@@ -18,6 +18,13 @@ public struct TextView: View {
 				}
 			}
 			
+			public func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+				guard let shouldChange = parent.shouldChange else {
+					return true
+				}
+				return shouldChange(range, text)
+			}
+			
 			public func textViewDidChange(_ textView: UITextView) {
 				parent.text = textView.text
 			}
@@ -49,6 +56,7 @@ public struct TextView: View {
 		private let isScrollingEnabled: Bool
 		private let isUserInteractionEnabled: Bool
 		private let shouldWaitUntilCommit: Bool
+		private let shouldChange: ShouldChangeHandler?
 		
 		public init(
 			text: Binding<String>,
@@ -67,7 +75,8 @@ public struct TextView: View {
 			isSelectable: Bool,
 			isScrollingEnabled: Bool,
 			isUserInteractionEnabled: Bool,
-			shouldWaitUntilCommit: Bool
+			shouldWaitUntilCommit: Bool,
+			shouldChange: ShouldChangeHandler? = nil
 		) {
 			_text = text
 			_isEditing = isEditing
@@ -87,6 +96,7 @@ public struct TextView: View {
 			self.isScrollingEnabled = isScrollingEnabled
 			self.isUserInteractionEnabled = isUserInteractionEnabled
 			self.shouldWaitUntilCommit = shouldWaitUntilCommit
+			self.shouldChange = shouldChange
 		}
 		
 		public func makeCoordinator() -> Coordinator {
@@ -145,6 +155,7 @@ public struct TextView: View {
 	public typealias ContentType = UITextContentType
 	public typealias Autocorrection = UITextAutocorrectionType
 	public typealias Autocapitalization = UITextAutocapitalizationType
+	public typealias ShouldChangeHandler = (NSRange, String) -> Bool
 	
 	public static let defaultFont = UIFont.preferredFont(forTextStyle: .body)
 	
@@ -171,6 +182,7 @@ public struct TextView: View {
 	private let isScrollingEnabled: Bool
 	private let isUserInteractionEnabled: Bool
 	private let shouldWaitUntilCommit: Bool
+	private let shouldChange: ShouldChangeHandler?
 	
 	public init(
 		text: Binding<String>,
@@ -194,7 +206,8 @@ public struct TextView: View {
 		isSelectable: Bool = true,
 		isScrollingEnabled: Bool = true,
 		isUserInteractionEnabled: Bool = true,
-		shouldWaitUntilCommit: Bool = true
+		shouldWaitUntilCommit: Bool = true,
+		shouldChange: ShouldChangeHandler? = nil
 	) {
 		_text = text
 		_isEditing = isEditing
@@ -219,6 +232,7 @@ public struct TextView: View {
 		self.isScrollingEnabled = isScrollingEnabled
 		self.isUserInteractionEnabled = isUserInteractionEnabled
 		self.shouldWaitUntilCommit = shouldWaitUntilCommit
+		self.shouldChange = shouldChange
 	}
 	
 	private var _placeholder: String? {
@@ -243,7 +257,8 @@ public struct TextView: View {
 			isSelectable: isSelectable,
 			isScrollingEnabled: isScrollingEnabled,
 			isUserInteractionEnabled: isUserInteractionEnabled,
-			shouldWaitUntilCommit: shouldWaitUntilCommit
+			shouldWaitUntilCommit: shouldWaitUntilCommit,
+			shouldChange: shouldChange
 		)
 	}
 	


### PR DESCRIPTION
This lets the client restrict what the user can type into the field, without
disabling editing altogether.