### PR TITLE
Set the default return key type to `.default`

### DIFF
--- a/Sources/TextView/TextView.swift
+++ b/Sources/TextView/TextView.swift
@@ -200,7 +200,7 @@ public struct TextView: View {
 		textColor: UIColor = .label,
 		placeholderColor: Color = .init(.placeholderText),
 		backgroundColor: UIColor = .clear,
-		returnType: UIReturnKeyType = .done,
+		returnType: UIReturnKeyType = .default,
 		contentType: ContentType? = nil,
 		autocorrection: Autocorrection = .default,
 		autocapitalization: Autocapitalization = .sentences,


### PR DESCRIPTION
I think that this is a better default than `.done`, and at least in the app where
I am using the text view, “Done” does the same thing as “Return” anyhow,
just with a different (confusing) appearance. (That is, “Done” may not make
sense for an app without special handling.)