### PR TITLE
Fix text editing on iOS 13

### DIFF
--- a/Sources/TextView/TextView.swift
+++ b/Sources/TextView/TextView.swift
@@ -285,4 +285,34 @@ public struct TextView: View {
 	}
 }
 
+struct TextView_Previews: PreviewProvider {
+	private struct PreviewView: View {
+		@State private var text: String = ""
+		@State private var isEditing: Bool = false
+
+		var body: some View {
+			VStack {
+				Button(action: { isEditing.toggle() }) {
+					Text("\(isEditing ? "Stop" : "Start") editing")
+						.padding()
+						.background(Color.white)
+				}
+				TextView(
+					text: $text,
+					isEditing: $isEditing,
+					placeholder: "Enter text here",
+					textAlignment: .natural,
+					backgroundColor: .systemBackground
+				)
+			}
+		}
+	}
+
+	static var previews: some View {
+		PreviewView()
+			.padding()
+			.background(Color.secondary.edgesIgnoringSafeArea(.all))
+	}
+}
+
 #endif

--- a/Sources/TextView/TextView.swift
+++ b/Sources/TextView/TextView.swift
@@ -43,7 +43,6 @@ public struct TextView: View {
 		private let textVerticalPadding: CGFloat
 		private let font: UIFont
 		private let textColor: UIColor
-		private let backgroundColor: UIColor
 		private let returnType: UIReturnKeyType
 		private let contentType: ContentType?
 		private let autocorrection: Autocorrection
@@ -65,7 +64,6 @@ public struct TextView: View {
 			textVerticalPadding: CGFloat,
 			font: UIFont,
 			textColor: UIColor,
-			backgroundColor: UIColor,
 			returnType: UIReturnKeyType,
 			contentType: ContentType?,
 			autocorrection: Autocorrection,
@@ -87,7 +85,6 @@ public struct TextView: View {
 			self.textVerticalPadding = textVerticalPadding
 			self.font = font
 			self.textColor = textColor
-			self.backgroundColor = backgroundColor
 			self.returnType = returnType
 			self.contentType = contentType
 			self.autocorrection = autocorrection
@@ -109,6 +106,7 @@ public struct TextView: View {
 		public func makeUIView(context: Context) -> UITextView {
 			let textView = UITextView()
 			textView.delegate = context.coordinator
+			textView.backgroundColor = nil
 			return textView
 		}
 		
@@ -129,7 +127,6 @@ public struct TextView: View {
 			textView.textAlignment = textAlignment
 			textView.font = font
 			textView.textColor = textColor
-			textView.backgroundColor = backgroundColor
 			textView.returnKeyType = returnType
 			textView.textContentType = contentType
 			textView.autocorrectionType = autocorrection
@@ -246,10 +243,6 @@ public struct TextView: View {
 		self.shouldChange = shouldChange
 	}
 	
-	private var _placeholder: String? {
-		text.isEmpty ? placeholder : nil
-	}
-	
 	private var representable: Representable {
 		.init(
 			text: $text,
@@ -259,7 +252,6 @@ public struct TextView: View {
 			textVerticalPadding: textVerticalPadding,
 			font: font,
 			textColor: textColor,
-			backgroundColor: backgroundColor,
 			returnType: returnType,
 			contentType: contentType,
 			autocorrection: autocorrection,
@@ -275,27 +267,21 @@ public struct TextView: View {
 		)
 	}
 	
-	public var body: some View {
-		GeometryReader { geometry in
-			ZStack {
-				self.representable
-				self._placeholder.map { placeholder in
-					Text(placeholder)
-						.font(.init(self.font))
-						.foregroundColor(self.placeholderColor)
-						.padding(.horizontal, self.placeholderHorizontalPadding)
-						.padding(.vertical, self.placeholderVerticalPadding)
-						.frame(
-							width: geometry.size.width,
-							height: geometry.size.height,
-							alignment: self.placeholderAlignment
-						)
-						.onTapGesture {
-							self.isEditing = true
-						}
-				}
-			}
+	@ViewBuilder
+	private var placeholderView: some View {
+		if let placeholder = text.isEmpty ? placeholder : nil {
+			Text(placeholder)
+				.font(.init(font))
+				.foregroundColor(placeholderColor)
+				.padding(.horizontal, placeholderHorizontalPadding)
+				.padding(.vertical, placeholderVerticalPadding)
 		}
+	}
+
+	public var body: some View {
+		representable
+			.background(placeholderView, alignment: placeholderAlignment)
+			.background(Color(backgroundColor))
 	}
 }
 


### PR DESCRIPTION
Commit 4490fb2 fixes an issue on iOS 13 where the `TextView` would not begin editing when tapping the placeholder. This fix is accomplished by moving the placeholder `Text` behind the `UITextView` in z-order. Fixes #35 

Commit e49785d adds an Xcode preview used to visually inspect & debug the `TextView`.

Demonstration of the issue on iOS 13
**Before:**
![Before](https://user-images.githubusercontent.com/915431/105550829-bb3be500-5cb6-11eb-9e3e-165047cdf8c1.gif)
**After:**
![After](https://user-images.githubusercontent.com/915431/105550849-c262f300-5cb6-11eb-99ee-47d3c9e3809f.gif)
