### PR TITLE
Remove empty test target from package declaration

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,10 +15,6 @@ let package = Package(
 		)
 	],
 	targets: [
-		.target(name: "TextView"),
-		.testTarget(
-			name: "TextViewTests",
-			dependencies: ["TextView"]
-		)
+		.target(name: "TextView")
 	]
 )


### PR DESCRIPTION
Removes the test target from the Swift Package since there are no tests within it, and only clutters the package's targets